### PR TITLE
JPG as output format of import

### DIFF
--- a/usr/bin/lernstick_backup
+++ b/usr/bin/lernstick_backup
@@ -247,7 +247,7 @@ do_backup()
 			mkdir -p "${SCREENSHOT_DIRECTORY}"
 			chmod 700 "${SCREENSHOT_DIRECTORY}"
 		fi
-		sudo -u user import -silent -window root - | convert - \
+		sudo -u user import -silent -window root jpg:- | convert - \
 			-filter Triangle \
 			-define filter:support=2 \
 			-unsharp 0.25x0.08+8.3+0.045 \


### PR DESCRIPTION
Hi Ronny

The automatic screenshots in the exam environment do not work anymore. I fixed the issue. The problem was a vulnerability in ghostscript (see https://www.kb.cert.org/vuls/id/332928/). Imagemagick now denies to convert images to `ps `format. This is solved by just forcing `import` to write a jpg.

Kind regards
Roman